### PR TITLE
Typefix to include ArrayBuffer

### DIFF
--- a/lib/ExifParserFactory.ts
+++ b/lib/ExifParserFactory.ts
@@ -5,7 +5,7 @@ function getGlobal() {
 }
 
 export class ExifParserFactory {
-  public static create(buffer: Buffer, global?: any) {
+  public static create(buffer: Buffer | ArrayBuffer, global?: any) {
     global = global || getGlobal();
     if (buffer instanceof global.ArrayBuffer) {
       const DOMBufferStream = require('./DOMBufferStream').DOMBufferStream;


### PR DESCRIPTION
A bit strange, that typescript didn't catch on to this before. Until now i used ArrayBuffer as input to type Buffer, which somehow worked, after i call the create function from another module, it's now complaining, that ArrayBuffer and Buffer (node buffer?) is not the same.