### PR TITLE
Changed ResolutionUnit type from string to number

### DIFF
--- a/lib/ExifData.ts
+++ b/lib/ExifData.ts
@@ -50,7 +50,7 @@ export interface ExifTags {
   GrayResponseCurve?: string;
   T4Options?: string;
   T6Options?: string;
-  ResolutionUnit?: string;
+  ResolutionUnit?: number;
   PageNumber?: number;
   ColorResponseUnit?: string;
   TransferFunction?: string;


### PR DESCRIPTION
`ResolutionUnit` type definition is incorrect. Parser returns it as number (as it should), and it is defined as string [here](https://github.com/bockoblur/ts-exif-parser/blob/5aac26aa39824fea5af675671174fc53b996e4d8/lib/ExifData.ts#L53).