### PR TITLE
fix: return undefined if date format is not valid

### DIFF
--- a/lib/DateUtil.ts
+++ b/lib/DateUtil.ts
@@ -78,12 +78,12 @@ export class DateUtil {
 
     //is the date in the standard "YYYY:MM:DD hh:mm:ss" format?
     let isSpecFormat = dateTimeStr.length === 19 &&
-      dateTimeStr.charAt(4) === ':';
+      dateTimeStr.charAt(4) === ':' &&
+      dateTimeStr.charAt(10) === " ";
     //is the date in the non-standard format,
     //"2004-09-04T23:39:06-08:00" to include a timezone?
     let isTimezoneFormat = dateTimeStr.length === 25 &&
       dateTimeStr.charAt(10) === 'T';
-    let timestamp;
 
     if (isTimezoneFormat) {
       return DateUtil.parseDateWithTimezoneFormat(dateTimeStr);

--- a/test/DateUtil.spec.ts
+++ b/test/DateUtil.spec.ts
@@ -53,8 +53,18 @@ describe('DateUtil', () => {
     const timestamp = DateUtil.parseDateWithTimezoneFormat(dateStr);
     assert.strictEqual(timestamp, undefined);
   });
-  it('should parseExifDate', () => {
-    assert.strictEqual(DateUtil.parseExifDate('1970:01:01 00:00:00'), 0);
-    assert.strictEqual(DateUtil.parseExifDate('1970-01-01T00:00:00-01:00'), 3600);
+
+  describe("parseExifDate", () => {
+    it('should parseExifDate', () => {
+      assert.strictEqual(DateUtil.parseExifDate('1970:01:01 00:00:00'), 0);
+      assert.strictEqual(DateUtil.parseExifDate('1970-01-01T00:00:00-01:00'), 3600);
+    });
+  
+    it('should return undefined when datestring has unsupported format', () => {
+      // date and time must be separated by either a 'space' or a 'T'
+      const dateStr = '2004:09:04-23:39:06';
+      const timestamp = DateUtil.parseExifDate(dateStr);
+      assert.strictEqual(timestamp, undefined);
+    });
   });
 });


### PR DESCRIPTION
I've seen cases in our logs with parsing exif data of photos from early 2000' where this library throws 

`'TypeError: Cannot read property 'split' of undefined'.`

The only place I could find where this error could be thrown should be fixed with this commit.

Added a test that fails without this fix.

Unfortuneatly I don't have access to the original photos that caused the error. I